### PR TITLE
Custom regions, correct MIME types, and doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ let driver = try S3Driver(
     secretKey: "secret"
 )
 
-services.register(driver)
+services.register(driver, as: NetworkDriver.self)
 ```
 `bucket`, `accessKey`and `secretKey` are required by the S3 driver, while `template`, `host` and `region` are optional. `region` will default to `eu-west-1` and `host` will default to `s3.amazonaws.com`.
 

--- a/Sources/Storage/FileEntity.swift
+++ b/Sources/Storage/FileEntity.swift
@@ -32,6 +32,9 @@ public struct FileEntity {
     /// The type of the file.
     var mime: String?
 
+    /// The ACL
+    var access: AccessControlList
+
     /**
         FileEntity's default initializer.
      
@@ -47,14 +50,15 @@ public struct FileEntity {
         fileName: String? = nil,
         fileExtension: String? = nil,
         folder: String? = nil,
-        mime: String? = nil
+        mime: String? = nil,
+        access: AccessControlList = .publicRead
     ) {
         self.bytes = bytes
         self.fileName = fileName
         self.fileExtension = fileExtension
         self.folder = folder
         self.mime = mime
-
+        self.access = access
         sanitize()
     }
 }

--- a/Sources/Storage/NetworkDriver.swift
+++ b/Sources/Storage/NetworkDriver.swift
@@ -70,7 +70,7 @@ public final class S3Driver: NetworkDriver {
         return try s3.upload(
             bytes: Data(bytes),
             path: path,
-            access: .publicRead,
+            access: entity.access,
             mime: entity.mime,
             on: container
         ).map { _ in

--- a/Sources/Storage/NetworkDriver.swift
+++ b/Sources/Storage/NetworkDriver.swift
@@ -27,6 +27,7 @@ public final class S3Driver: NetworkDriver {
         accessKey: String,
         secretKey: String,
         region: Region = .euWest1,
+        customRegion: String? = nil,
         pathTemplate: String = ""
     ) throws {
         self.pathBuilder = try ConfigurablePathBuilder(template: pathTemplate)
@@ -34,7 +35,7 @@ public final class S3Driver: NetworkDriver {
             host: "\(bucket).\(host)",
             accessKey: accessKey,
             secretKey: secretKey,
-            region: region
+            region: customRegion ?? region.rawValue
         )
     }
 
@@ -70,6 +71,7 @@ public final class S3Driver: NetworkDriver {
             bytes: Data(bytes),
             path: path,
             access: .publicRead,
+            mime: entity.mime,
             on: container
         ).map { _ in
             return path

--- a/Sources/Storage/Storage.swift
+++ b/Sources/Storage/Storage.swift
@@ -47,6 +47,7 @@ public class Storage {
         fileExtension: String? = nil,
         mime: String? = nil,
         folder: String? = nil,
+        access: AccessControlList = .publicRead,
         on container: Container
     ) throws -> Future<String> {
         var entity = FileEntity(
@@ -54,7 +55,8 @@ public class Storage {
             fileName: fileName,
             fileExtension: fileExtension,
             folder: folder,
-            mime: mime
+            mime: mime,
+            access: access
         )
 
         return try upload(entity: &entity, on: container)

--- a/Tests/StorageTests/AWSSignerTestSuite.swift
+++ b/Tests/StorageTests/AWSSignerTestSuite.swift
@@ -265,7 +265,7 @@ extension AWSSignerTestSuite {
         var auth = AWSSignatureV4(
             service: "service",
             host: host,
-            region: .usEast1,
+            region: Region.usEast1.rawValue,
             accessKey: "AKIDEXAMPLE",
             secretKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
         )


### PR DESCRIPTION
## Summary

- Adds the ability to set custom regions, to allow for S3 compatible non-Amazon hosts
- Correctly sets the `MediaType` on the upload `Request` (`req.http.contentType`)
- Exposes `AccessControlList` parameter on `upload` method
- Updates the documentation to reflect the correct way to register the Service (`services.register(driver, as: NetworkDriver.self)`)

## Custom regions

I know there has been discussion about a better way to handle custom regions rather than a hardcoded `enum`, but honestly, the current way seems fine to me. The enum is simple and will use the type system to catch errors. Using a different field for `customRegion` allows users to override that entirely without creating a new convoluted type which attempts to be both an enum and String.

## MIME Types
Regarding the MediaType, maybe there's a more graceful way to handle this, but I'd prefer to let Vapor parse the MIME type.

## ACL
I added `AccessControlList` as a parameter on `FileEntity`, allowing all upload methods to work with ACL. The `upload(bytes:…` method was updated with an `access` parameter, so you can now specify the access level at the time of upload.

## Documentation
This PR also updates the code sample in the README—the old version will give runtime errors.

Thanks for this library! 