### PR TITLE
Register Driver as NetworkDriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ let driver = try S3Driver(
     secretKey: "secret"
 )
 
-services.register(driver)
+services.register(driver, as: NetworkDriver.self)
 ```
 `bucket`, `accessKey`and `secretKey` are required by the S3 driver, while `template`, `host` and `region` are optional. `region` will default to `eu-west-1` and `host` will default to `s3.amazonaws.com`.
 


### PR DESCRIPTION
Hi,

first of all: thank you for this package!

Preparing the driver config with 
```swift
services.register(driver)
```
resulted in an error for me:

```
[ ERROR ] ServiceError.make: No services are available for 'NetworkDriver'. (Container.swift:112)
[ DEBUG ] Suggested fixes for ServiceError.make: Register a service for 'NetworkDriver'. `services.register(NetworkDriver.self) { ... }`. (ErrorMiddleware.swift:26)
```

When I change it to the following, everything worked for me

```swift
services.register(driver, as: NetworkDriver.self)
```

I'm using Vapor 3.3.0 and Swift 4.2.1 right now.

I hope this fix in the README.me is helpful and correct.