### PR TITLE
Use proper date format for credential scope date

### DIFF
--- a/Sources/Storage/Utilities/S3.swift
+++ b/Sources/Storage/Utilities/S3.swift
@@ -179,7 +179,7 @@ public struct AWSSignatureV4 {
         let date = unitTestDate ?? Date()
         let dateFormatter = DateFormatter()
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-        dateFormatter.dateFormat = "YYYYMMdd"
+        dateFormatter.dateFormat = "yyyyMMdd"
         return dateFormatter.string(from: date)
     }
 }
@@ -191,7 +191,7 @@ extension AWSSignatureV4 {
         hash: String
     ) {
         headers["Host"] = host
-        headers["X-Amz-Date"] = amzDate
+        headers["x-amz-date"] = amzDate
 
         if hash != "UNSIGNED-PAYLOAD" {
             headers["x-amz-content-sha256"] = hash
@@ -279,7 +279,7 @@ extension AWSSignatureV4 {
         )
 
         var requestHeaders: [String: String] = [
-            "X-Amz-Date": amzDate,
+            "x-amz-date": amzDate,
             "Content-Type": contentType,
             "x-amz-content-sha256": payloadHash,
             "Authorization": authorizationHeader,


### PR DESCRIPTION
Fixes a critical issue that would prevent uploading files until next week:

```
<Error><Code>AuthorizationHeaderMalformed</Code><Message>The authorization header is malformed; Invalid credential date. Date is not the same as X-Amz-Date.</Message><RequestId>F334901946B9A8AB</RequestId><HostId>oIdYRXpEFjbkfYBbIy3LC/OG1KR40Dc/llqw8zdrRV2R/zWFx6CIctZ2IpN3NEVXpoqvaP17In4=</HostId></Error> (NetworkDriver.swift:103)
```

**Reason:**
One of the `DateFormatters` used `YYYY` instead of `yyyy` which lead to a wrong date (see: https://stackoverflow.com/questions/15133549/difference-between-yyyy-and-yyyy-in-nsdateformatter).